### PR TITLE
Pull v2 data

### DIFF
--- a/.github/workflows/pull-data.yaml
+++ b/.github/workflows/pull-data.yaml
@@ -102,7 +102,7 @@ jobs:
             END=$(echo "$CONFIG" | jq -r '.end')
 
             echo "Pull data for ${ZONE} until ${END}..."
-            go run download.go --zone ${ZONE} --from ${FROM} --end ${END} --output ./github-pages/api/energy-price/ --limit 0
+            go run download.go --zone ${ZONE} --from ${FROM} --end ${END} --output ./github-pages/api/energy-price/ --limit 0 --v2date 1758326400
             echo "changed=true" >> $GITHUB_ENV
           done
 


### PR DESCRIPTION
Version 2 data is available for testing purposes and is currently just calculated values from version 1 data, but we are testing the endpoint and our handling to produce both version 1 and version 2 data.

Note the option given to download is temporary and the version 2 data produced will be removed once "real" version 2 data is available.