### PR TITLE
chore: update tariff codes for Konstant Net

### DIFF
--- a/configuration/networks.json
+++ b/configuration/networks.json
@@ -245,13 +245,8 @@
       "gln": 5790000683345,
       "codes": [
         {
-          "from": 1780264800,
-          "to": null,
-          "code": "C_FBTNTR_B"
-        },
-        {
           "from": 0,
-          "to": 1780264800,
+          "to": null,
           "code": "245-NT01T"
         }
       ]


### PR DESCRIPTION
undo #157 / #158 for now.